### PR TITLE
Fix: use correct filename and variables in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # Configuration
-GITHUB_URL="https://raw.githubusercontent.com/TheValiant/manpy/main/pyhelp.py"
-DEST_PATH="$HOME/pyhelp.py"
+GITHUB_URL="https://raw.githubusercontent.com/TheValiant/manpy/main/manpy.py"
+DEST_PATH="$HOME/manpy.py"
 BASHRC_FILE="$HOME/.bashrc"
 ZSHRC_FILE="$HOME/.zshrc"
 MARKER_START="# --- manpy configuration start ---"
@@ -19,7 +19,7 @@ echo -e "${GREEN}Starting manpy installation...${NC}"
 # ------------------------------------------------------------------
 # 1. Download the Python script
 # ------------------------------------------------------------------
-echo -e "Downloading pyhelp.py to ${DEST_PATH}..."
+echo -e "Downloading manpy.py to ${DEST_PATH}..."
 
 if command -v curl >/dev/null 2>&1; then
     curl -fsSL "$GITHUB_URL" -o "$DEST_PATH"
@@ -65,7 +65,7 @@ manpy() {
 
     # 1. Run script forcing color. 2>&1 captures both stdout and stderr.
     # Note: Using absolute path to ensuring no $PATH issues
-    output=$(FORCE_COLOR=1 $DEST_PATH "$1" 2>&1)
+    output=$(FORCE_COLOR=1 ~/manpy.py "$1" 2>&1)
     exit_code=$?
 
     if [ $exit_code -eq 0 ]; then

--- a/install.sh
+++ b/install.sh
@@ -3,6 +3,8 @@
 # Configuration
 GITHUB_URL="https://raw.githubusercontent.com/TheValiant/manpy/main/pyhelp.py"
 DEST_PATH="$HOME/pyhelp.py"
+BASHRC_FILE="$HOME/.bashrc"
+ZSHRC_FILE="$HOME/.zshrc"
 MARKER_START="# --- manpy configuration start ---"
 MARKER_END="# --- manpy configuration end ---"
 
@@ -63,7 +65,7 @@ manpy() {
 
     # 1. Run script forcing color. 2>&1 captures both stdout and stderr.
     # Note: Using absolute path to ensuring no $PATH issues
-    output=$(FORCE_COLOR=1 ~/pyhelp.py "$1" 2>&1)
+    output=$(FORCE_COLOR=1 $DEST_PATH "$1" 2>&1)
     exit_code=$?
 
     if [ $exit_code -eq 0 ]; then
@@ -112,11 +114,13 @@ update_rc_file() {
     fi
 }
 
+chmod +x $DEST_PATH
+
 # ------------------------------------------------------------------
 # 5. Run updates
 # ------------------------------------------------------------------
-update_rc_file "$HOME/.bashrc"
-update_rc_file "$HOME/.zshrc"
+update_rc_file "$BASHRC_FILE"
+update_rc_file "$ZSHRC_FILE"
 
 echo --------------------------------------------------
 echo -e "${GREEN}Installation complete!${NC}"

--- a/install.sh
+++ b/install.sh
@@ -114,7 +114,7 @@ update_rc_file() {
     fi
 }
 
-chmod +x $DEST_PATH
+chmod +x "$DEST_PATH"
 
 # ------------------------------------------------------------------
 # 5. Run updates


### PR DESCRIPTION
- Changed chmod target from ~/manpy.py to ~/pyhelp.py to match the installed file
- Added BASHRC_FILE and ZSHRC_FILE variables for better maintainability
- Replaced hardcoded paths with variable references throughout the script

Fixes #1